### PR TITLE
Bug: Fixed term / index comparison on voting

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,7 +228,7 @@ class Raft extends EventEmitter {
           if (raft.log) {
             const { index, term } = await raft.log.getLastInfo();
 
-            if (index > packet.last.index && term > packet.last.term) {
+            if (index > packet.last.index && term >= packet.last.term) {
               raft.emit('vote', packet, false);
 
               return write(await raft.packet('voted', { granted: false }));


### PR DESCRIPTION
In the logic for when a node receives a vote request, it goes through a set of comparisons to know how to vote. If a candidate matches one of these failure conditions, the node votes "false" on that candidate. If all of the checks pass, the nodes vote "true", placing their vote for the candidate to be a leader. In terms of placing votes, specifically in the first term, if a candidate comes through and says they are term A, index B, the nodes that receive this vote request will only vote no if the term AND the index is greater. This causes data loss issues for when the term is the same but the nodes receiving the candidate request have a newer index.

This PR addresses this issue by setting the term condition to be >=, so the node will reject the candidates vote request if the current node is in the same term and has newer data.